### PR TITLE
Handle UUID values in WebAuthn test token creation

### DIFF
--- a/tests/test_auth/test_webauthn.py
+++ b/tests/test_auth/test_webauthn.py
@@ -47,9 +47,13 @@ def create_reauth_token(user_id: str, session_id: str, mfa_authenticated: bool) 
     Creates a re-authentication (step-up) token for verifying sensitive operations.
     """
     expiration_time = datetime.utcnow() + timedelta(minutes=5)  
+    # Ensure all claim values are JSON serializable. PyJWT/json can't encode
+    # ``UUID`` objects directly, so cast anything passed in to ``str``. This
+    # allows tests to supply either UUIDs or raw strings without triggering
+    # ``TypeError: Object of type UUID is not JSON serializable``.
     claims = {
-        "sub": user_id,
-        "session_id": session_id,
+        "sub": str(user_id),
+        "session_id": str(session_id),
         "mfa_authenticated": mfa_authenticated,
         "exp": expiration_time,
         "typ": "reauth",


### PR DESCRIPTION
## Summary
- Cast `user_id` and `session_id` to strings when creating WebAuthn re-auth tokens in tests
- Prevent `TypeError` when JWT encoder serializes UUID objects

## Testing
- `pytest tests/test_auth/test_webauthn.py::test_webauthn_registration_options -q` *(fails: OSError: Multiple exceptions: [Errno 111] Connect call failed ('::1', 5432, 0, 0), [Errno 111] Connect call failed ('127.0.0.1', 5432))*

------
https://chatgpt.com/codex/tasks/task_e_68b2ec18f1148321b9b5389e33dd5d05